### PR TITLE
Fix semantic release for v25

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,11 +1,64 @@
 branches:
   - main
 
-preset: conventionalcommits
-
 plugins:
-  - "@semantic-release/commit-analyzer"
-  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/commit-analyzer"
+    - preset: conventionalcommits
+      releaseRules:
+        - breaking: true
+          release: major
+        - type: feat
+          breaking: true
+          release: major
+        - type: feat
+          release: minor
+        - type: fix
+          release: patch
+        - type: perf
+          release: patch
+        - type: revert
+          release: patch
+        - type: docs
+          scope: README
+          release: patch
+        - type: refactor
+          release: patch
+        - type: style
+          release: false
+        - type: chore
+          release: false
+        - type: test
+          release: false
+        - type: build
+          release: false
+        - type: ci
+          release: false
+  - - "@semantic-release/release-notes-generator"
+    - preset: conventionalcommits
+      presetConfig:
+        types:
+          - type: feat
+            section: Features
+          - type: fix
+            section: Bug Fixes
+          - type: perf
+            section: Performance Improvements
+          - type: revert
+            section: Reverts
+          - type: docs
+            section: Documentation
+          - type: style
+            section: Styles
+          - type: refactor
+            section: Code Refactoring
+          - type: test
+            section: Tests
+          - type: build
+            section: Build System
+          - type: ci
+            section: Continuous Integration
+          - type: chore
+            section: Chores
   - "@semantic-release/changelog"
   - - "@semantic-release/github"
     - assets:
@@ -21,63 +74,3 @@ plugins:
     - assets:
         - "CHANGELOG.md"
       message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-
-analyzeCommits:
-  - path: "@semantic-release/commit-analyzer"
-    releaseRules:
-      - breaking: true
-        release: major
-      - type: feat
-        breaking: true
-        release: major
-      - type: feat
-        release: minor
-      - type: fix
-        release: patch
-      - type: perf
-        release: patch
-      - type: revert
-        release: patch
-      - type: docs
-        scope: README
-        release: patch
-      - type: refactor
-        release: patch
-      - type: style
-        release: false
-      - type: chore
-        release: false
-      - type: test
-        release: false
-      - type: build
-        release: false
-      - type: ci
-        release: false
-
-generateNotes:
-  - path: "@semantic-release/release-notes-generator"
-    preset: conventionalcommits
-    presetConfig:
-      types:
-        - type: feat
-          section: Features
-        - type: fix
-          section: Bug Fixes
-        - type: perf
-          section: Performance Improvements
-        - type: revert
-          section: Reverts
-        - type: docs
-          section: Documentation
-        - type: style
-          section: Styles
-        - type: refactor
-          section: Code Refactoring
-        - type: test
-          section: Tests
-        - type: build
-          section: Build System
-        - type: ci
-          section: Continuous Integration
-        - type: chore
-          section: Chores 


### PR DESCRIPTION
- Moved releaseRules + preset: conventionalcommits inline with the commit-analyzer plugin
- Moved preset + presetConfig inline with the release-notes-generator plugin
- Removed the orphaned top-level preset, analyzeCommits, and generateNotes blocks