### PR TITLE
Revert custom https_proxy changes

### DIFF
--- a/pkg/azure/config.go
+++ b/pkg/azure/config.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 
 	"golang.org/x/oauth2"
@@ -97,18 +96,12 @@ func (c *AZConfig) NewService(resourceIndex int) (*AZService, error) {
 		return nil, fmt.Errorf("unable to load Azure identity CA certs: %w", err)
 	}
 
-	httpClient := oauthConf.Client(context.TODO())
-	if os.Getenv("HTTPS_PROXY") != "" {
-		proxyURL, err := url.Parse(os.Getenv("HTTPS_PROXY"))
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse HTTPS_PROXY: %w", err)
-		}
-		httpClient.Transport = &http.Transport{
-			Proxy: http.ProxyURL(proxyURL),
-		}
-	}
-
-	return &AZService{BaseURL: c.Resources[resourceIndex], Publisher: c.Publisher, httpClient: httpClient, IdentityCACerts: certs}, nil
+	return &AZService{
+		BaseURL:         c.Resources[resourceIndex],
+		Publisher:       c.Publisher,
+		httpClient:      oauthConf.Client(context.TODO()),
+		IdentityCACerts: certs,
+	}, nil
 }
 
 // StartService starts the Azure service

--- a/pkg/azure/config_test.go
+++ b/pkg/azure/config_test.go
@@ -59,22 +59,6 @@ func TestStartService(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		{
-			name: "start service success with https proxy",
-			modifyConfig: func() {
-				prepareConfig()
-				os.Setenv("HTTPS_PROXY", "http://localhost:8200")
-			},
-			wantErr: false,
-		},
-		{
-			name: "start service failure with invalid https proxy",
-			modifyConfig: func() {
-				prepareConfig()
-				os.Setenv("HTTPS_PROXY", "http://localhost:8200%/")
-			},
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/google/config.go
+++ b/pkg/google/config.go
@@ -2,8 +2,6 @@ package google
 
 import (
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
@@ -31,26 +29,9 @@ type GCEConfig struct {
 var Config = GCEConfig{
 	ServiceAccountKeyFile: os.Getenv("GOOGLE_KEYFILE"),
 	JwkURL:                os.Getenv("GOOGLE_JWK_URL"),
-	clientOpts:            prepareClientOpts,
 }
 
 type getOpts func() ([]option.ClientOption, error)
-
-func prepareClientOpts() ([]option.ClientOption, error) {
-	opts := []option.ClientOption{}
-	if os.Getenv("HTTPS_PROXY") != "" {
-		proxyURL, err := url.Parse(os.Getenv("HTTPS_PROXY"))
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse HTTPS_PROXY: %w", err)
-		}
-		opts = append(opts, option.WithHTTPClient(&http.Client{
-			Transport: &http.Transport{
-				Proxy: http.ProxyURL(proxyURL),
-			},
-		}))
-	}
-	return opts, nil
-}
 
 // NewService creates a new cloudidentity.service from the GCEConfig.
 func (c GCEConfig) NewService() (*Service, error) {

--- a/pkg/google/config_test.go
+++ b/pkg/google/config_test.go
@@ -45,24 +45,6 @@ func TestStartService(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		{
-			name: "test start service success with https proxy",
-			modifyConfig: func() {
-				Config.clientOpts = prepareClientOpts
-				os.Setenv("GOOGLE_KEYFILE", "testdata/google-keyfile.json")
-				os.Setenv("HTTPS_PROXY", "http://localhost:8200")
-			},
-			wantErr: false,
-		},
-		{
-			name: "test start service failure with invalid https proxy",
-			modifyConfig: func() {
-				Config.clientOpts = prepareClientOpts
-				os.Setenv("GOOGLE_KEYFILE", "testdata/google-keyfile.json")
-				os.Setenv("HTTPS_PROXY", "http://localhost:8200%/")
-			},
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- go http client default transport natively respects ProxyFromEnvironment
- custom proxy configuration not required for now